### PR TITLE
Update formatting constants to raw strings to fix unescaped error

### DIFF
--- a/khayyam/formatting/constants.py
+++ b/khayyam/formatting/constants.py
@@ -137,21 +137,21 @@ AM_PM_ASCII = {
 
 
 FORMAT_DIRECTIVE_REGEX = '%[a-zA-Z%]'
-YEAR_REGEX = '\d{1,4}'
-SHORT_YEAR_REGEX = '\d{2}'
+YEAR_REGEX = r'\d{1,4}'
+SHORT_YEAR_REGEX = r'\d{2}'
 MONTH_REGEX = '([0]?[1-9]|1[0-2])'
-DAY_REGEX = '([0]?[1-9]|[12]\d|3[01])' # 1-31
-DAY_OF_YEAR_REGEX = '([0]{0,2}[1-9]|[0]?[1-9]\d|[12]\d{2}|3[0-5]\d|36[0-6])' # 1-366
-WEEK_OF_YEAR_REGEX = '([0]?\d|[1-4]\d|5[0-3])'  # 0-53
+DAY_REGEX = r'([0]?[1-9]|[12]\d|3[01])' # 1-31
+DAY_OF_YEAR_REGEX = r'([0]{0,2}[1-9]|[0]?[1-9]\d|[12]\d{2}|3[0-5]\d|36[0-6])' # 1-366
+WEEK_OF_YEAR_REGEX = r'([0]?\d|[1-4]\d|5[0-3])'  # 0-53
 WEEKDAY_REGEX = '[0-6]'
 AM_PM_REGEX = '(%s)' % '|'.join(AM_PM.values())
 AM_PM_ASCII_REGEX = '([aA][mM]|[pP][mM])'
 HOUR12_REGEX = '(0[1-9]|1[0-2])'
-HOUR24_REGEX = '([01]\d|2[0-3])'
-MINUTE_REGEX = '([0]?\d|[1-5]\d)'
-SECOND_REGEX = '([0]?\d|[1-5]\d)'
-MICROSECOND_REGEX = '\d{1,6}'
-UTC_OFFSET_FORMAT_REGEX = '([-+]?\d{2}:\d{2}|)'
+HOUR24_REGEX = r'([01]\d|2[0-3])'
+MINUTE_REGEX = r'([0]?\d|[1-5]\d)'
+SECOND_REGEX = r'([0]?\d|[1-5]\d)'
+MICROSECOND_REGEX = r'\d{1,6}'
+UTC_OFFSET_FORMAT_REGEX = r'([-+]?\d{2}:\d{2}|)'
 TZ_NAME_FORMAT_REGEX='.+'
 
 PERSIAN_YEAR_REGEX = '[۰۱۲۳۴۵۶۷۸۹]{1,4}'

--- a/khayyam/formatting/directives/tz.py
+++ b/khayyam/formatting/directives/tz.py
@@ -27,7 +27,7 @@ class UTCOffsetDirective(Directive):
         exp = ctx[self.name]
         if exp.strip() == '':
             return
-        regex = '(?P<posneg>[-+]?)(?P<hour>\d{2}):(?P<minute>\d{2})'
+        regex = r'(?P<posneg>[-+]?)(?P<hour>\d{2}):(?P<minute>\d{2})'
         match = re.match(regex, exp)
         d = match.groupdict()
         posneg = lambda i: 0 - i if d['posneg'] == '-' else i


### PR DESCRIPTION
Update formatting constants to [raw strings to fix error in Python 3.12](https://docs.python.org/3/whatsnew/3.12.html#other-language-changes)

- Changed formatting to raw string.
- This change addresses the unscaped error encountered in Python 3.12.
- Ensured all regex patterns are now using raw string literals for proper escaping.